### PR TITLE
Fix rounding cords for "/setpos1" and "/setpos2"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,6 @@ loader_version=0.14.19-babric.3-bta
 halplibe_version=3.1.1
 
 # Mod
-mod_version=1.1.1-7.1
+mod_version=1.1.2-7.1
 mod_group=cookie
 mod_name=worldedit

--- a/src/main/java/cookie/worldedit/commands/CommandSetPos1.java
+++ b/src/main/java/cookie/worldedit/commands/CommandSetPos1.java
@@ -13,9 +13,9 @@ public class CommandSetPos1 extends Command {
 
     @Override
     public boolean execute(CommandHandler commandHandler, CommandSender commandSender, String[] strings) {
-        int[] hitPosition = {(int) commandSender.getPlayer().x, ((int) commandSender.getPlayer().y - 1), (int) commandSender.getPlayer().z};
+        int[] hitPosition = {(int) Math.floor(commandSender.getPlayer().x), ((int) commandSender.getPlayer().y - 1), (int) Math.floor(commandSender.getPlayer().z)};
         WandPlayerData.primaryPositions.put(commandSender.getPlayer().username, hitPosition);
-        commandSender.sendMessage("Set primary position at " + commandSender.getPlayer().x + ", " + (commandSender.getPlayer().y - 1) + ", " + commandSender.getPlayer().z);
+        commandSender.sendMessage("Set primary position at " + hitPosition[0] + ", " + hitPosition[1] + ", " + hitPosition[2]);
         return true;
     }
 

--- a/src/main/java/cookie/worldedit/commands/CommandSetPos2.java
+++ b/src/main/java/cookie/worldedit/commands/CommandSetPos2.java
@@ -13,9 +13,9 @@ public class CommandSetPos2 extends Command {
 
     @Override
     public boolean execute(CommandHandler commandHandler, CommandSender commandSender, String[] strings) {
-        int[] hitPosition = {(int) commandSender.getPlayer().x, ((int) commandSender.getPlayer().y - 1), (int) commandSender.getPlayer().z};
+        int[] hitPosition = {(int) Math.floor(commandSender.getPlayer().x), ((int) commandSender.getPlayer().y - 1), (int) Math.floor(commandSender.getPlayer().z)};
         WandPlayerData.secondaryPositions.put(commandSender.getPlayer().username, hitPosition);
-        commandSender.sendMessage("Set secondary position at " + commandSender.getPlayer().x + ", " + (commandSender.getPlayer().y - 1) + ", " + commandSender.getPlayer().z);
+        commandSender.sendMessage("Set secondary position at " + hitPosition[0] + ", " + hitPosition[1] + ", " + hitPosition[2]);
         return true;
     }
 


### PR DESCRIPTION
Mainly on negative x and z. The output of the positions themselves has also been changed.

And question: is it normal that the point is placed under the player? Maybe this needs to be fixed too?