### PR TITLE
Update mod to the newest version of Babric (v7.2-pre1)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic",
+    "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A port and fixed up version of WorldEdit for BTA!
 
 ## Prerequisites
 - JRE for Java 17 or Java 8 ([Eclipse Temurin](https://adoptium.net/temurin/releases/) recommended)
-- Babric for BTA 7.1
+- Babric for BTA 7.2-pre1
 
 ## Usage instructions
 1. If in singleplayer with cheats enabled, or in Multiplayer and have op, type //wand, or //setpos1 and //setpos2.

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'babric-loom' version '1.1.+'
-    id 'java'
+	id 'babric-loom' version '1.4.+'
+	id 'java'
 }
 
 group = project.mod_group
@@ -8,115 +8,118 @@ archivesBaseName = project.mod_name
 version = project.mod_version
 
 loom {
-    gluedMinecraftJar()
-    noIntermediateMappings()
-    customMinecraftManifest.set("https://github.com/Turnip-Labs/bta-manifest-repo/releases/download/v${project.bta_version}/${project.bta_version}.json")
+	gluedMinecraftJar()
+	noIntermediateMappings()
+	customMinecraftManifest.set("https://github.com/Turnip-Labs/bta-manifest-repo/releases/download/v${project.bta_version}/${project.bta_version}.json")
 }
 
 repositories {
-    mavenCentral()
-    maven { url = "https://jitpack.io" }
-    maven {
-        name = 'Babric'
-        url = 'https://maven.glass-launcher.net/babric'
-    }
-    maven {
-        name = 'Fabric'
-        url = 'https://maven.fabricmc.net/'
-    }
-    ivy {
-        url = "https://github.com/Better-than-Adventure"
-        patternLayout {
-            artifact "[organisation]/releases/download/v[revision]/[module].jar"
-            m2compatible = true
-        }
-        metadataSources { artifact() }
-    }
-    ivy {
-        url = "https://github.com/Turnip-Labs"
-        patternLayout {
-            artifact "[organisation]/releases/download/v[revision]/[module]-[revision].jar"
-            m2compatible = true
-        }
-        metadataSources { artifact() }
-    }
-    ivy {
-        url = "https://github.com/Turnip-Labs"
-        patternLayout {
-            artifact "[organisation]/releases/download/[revision]/[module]-[revision].jar"
-            m2compatible = true
-        }
-        metadataSources { artifact() }
-    }
-    ivy {
-        url = "https://github.com/Turnip-Labs"
-        patternLayout {
-            artifact "[organisation]/releases/download/[revision]/[module]-bta-[revision].jar"
-            m2compatible = true
-        }
-        metadataSources { artifact() }
-    }
-    ivy {
-        url = "https://piston-data.mojang.com"
-        patternLayout {
-            artifact "v1/[organisation]/[revision]/[module].jar"
-            m2compatible = true
-        }
-        metadataSources { artifact() }
-    }
-    ivy {
-        url = "https://github.com/MartinSVK12"
-        patternLayout {
-            artifact "[organisation]/releases/download/[revision]/[module]-[revision].jar"
-            m2compatible = true
-        }
-        metadataSources { artifact() }
-    }
+	mavenCentral()
+	maven { url = "https://jitpack.io" }
+	maven {
+		name = 'Babric'
+		url = 'https://maven.glass-launcher.net/babric'
+	}
+	maven {
+		name = 'Fabric'
+		url = 'https://maven.fabricmc.net/'
+	}
+	ivy {
+		url = "https://github.com/Better-than-Adventure"
+		patternLayout {
+			artifact "[organisation]/releases/download/v[revision]/[module].jar"
+			m2compatible = true
+		}
+		metadataSources { artifact() }
+	}
+	ivy {
+		url = "https://github.com/Turnip-Labs"
+		patternLayout {
+			artifact "[organisation]/releases/download/v[revision]/[module]-[revision].jar"
+			m2compatible = true
+		}
+		metadataSources { artifact() }
+	}
+	ivy {
+		url = "https://github.com/Turnip-Labs"
+		patternLayout {
+			artifact "[organisation]/releases/download/[revision]/[module]-[revision].jar"
+			m2compatible = true
+		}
+		metadataSources { artifact() }
+	}
+	ivy {
+		url = "https://github.com/Turnip-Labs"
+		patternLayout {
+			artifact "[organisation]/releases/download/[revision]/[module]-bta-[revision].jar"
+			m2compatible = true
+		}
+		metadataSources { artifact() }
+	}
+	ivy {
+		url = "https://piston-data.mojang.com"
+		patternLayout {
+			artifact "v1/[organisation]/[revision]/[module].jar"
+			m2compatible = true
+		}
+		metadataSources { artifact() }
+	}
+	ivy {
+		url = "https://github.com/MartinSVK12"
+		patternLayout {
+			artifact "[organisation]/releases/download/[revision]/[module]-[revision].jar"
+			m2compatible = true
+		}
+		metadataSources { artifact() }
+	}
 }
 
 dependencies {
-    minecraft "bta-download-repo:bta:${project.bta_version}"
-    mappings loom.layered() {}
+	minecraft "bta-download-repo:bta:${project.bta_version}"
+	mappings loom.layered() {}
 
-    modRuntimeOnly "objects:client:43db9b498cb67058d2e12d394e6507722e71bb45" // https://piston-data.mojang.com/v1/objects/43db9b498cb67058d2e12d394e6507722e71bb45/client.jar
-    modImplementation "fabric-loader:fabric-loader:${project.loader_version}"
+	modRuntimeOnly "objects:client:43db9b498cb67058d2e12d394e6507722e71bb45" // https://piston-data.mojang.com/v1/objects/43db9b498cb67058d2e12d394e6507722e71bb45/client.jar
+	modImplementation "fabric-loader:fabric-loader:${project.loader_version}"
 
-    // Helper library
-    // modImplementation "com.github.Turnip-Labs:bta-halplibe:${project.halplibe_version}"
+	// Helper library
+	// If you do not need Halplibe you can comment this line out or delete this line
+	modImplementation "com.github.Turnip-Labs:bta-halplibe:${project.halplibe_version}"
 
-    modImplementation "ModMenu:ModMenu:2.0.3"
+	modImplementation "ModMenu:ModMenu:${project.mod_menu_version}"
 
-    implementation "org.slf4j:slf4j-api:1.8.0-beta4"
-    implementation "org.apache.logging.log4j:log4j-slf4j18-impl:2.16.0"
+	implementation "org.slf4j:slf4j-api:1.8.0-beta4"
+	implementation "org.apache.logging.log4j:log4j-slf4j18-impl:2.16.0"
 
-    implementation 'com.google.guava:guava:30.0-jre'
-    implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
-    var log4jVersion = "2.20.0"
-    implementation("org.apache.logging.log4j:log4j-core:${log4jVersion}")
-    implementation("org.apache.logging.log4j:log4j-api:${log4jVersion}")
-    implementation("org.apache.logging.log4j:log4j-1.2-api:${log4jVersion}")
+	implementation 'com.google.guava:guava:33.0.0-jre'
+	implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
+	var log4jVersion = "2.20.0"
+	implementation("org.apache.logging.log4j:log4j-core:${log4jVersion}")
+	implementation("org.apache.logging.log4j:log4j-api:${log4jVersion}")
+	implementation("org.apache.logging.log4j:log4j-1.2-api:${log4jVersion}")
+
+	include(implementation("org.apache.commons:commons-lang3:3.12.0"))
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-    withSourcesJar()
+	sourceCompatibility = JavaVersion.VERSION_1_8
+	targetCompatibility = JavaVersion.VERSION_1_8
+	withSourcesJar()
 }
 
-tasks.withType(JavaCompile) {
-    options.release.set 8
+tasks.withType(JavaCompile).configureEach {
+	options.release.set 8
 }
 
 jar {
-    from("LICENSE") {
-        rename { "${it}_${archivesBaseName}" }
-    }
+	from("LICENSE") {
+		rename { "${it}_${archivesBaseName}" }
+	}
 }
 
 processResources {
-    inputs.property "version", version
+	inputs.property "version", version
 
-    filesMatching("fabric.mod.json") {
-        expand "version": version
-    }
+	filesMatching("fabric.mod.json") {
+		expand "version": version
+	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,16 @@
 org.gradle.jvmargs=-Xmx2G
 
 # BTA
-bta_version=7.1-pre1
+bta_version=7.2-pre1
 
-# Loader
-loader_version=0.14.19-babric.3-bta
+# Loader & Mod Menu
+loader_version=0.15.6-babric.6-bta
+mod_menu_version=2.0.6
 
 # HalpLibe
-halplibe_version=3.1.1
+halplibe_version=4.0.1
 
 # Mod
-mod_version=1.1.2-7.1
+mod_version=1.1.2-7.2-pre1
 mod_group=cookie
 mod_name=worldedit

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17

--- a/src/main/java/cookie/worldedit/commands/CommandCopy.java
+++ b/src/main/java/cookie/worldedit/commands/CommandCopy.java
@@ -20,7 +20,7 @@ public class CommandCopy extends Command {
             int[] secondaryPos = WandPlayerData.secondaryPositions.get(commandSender.getPlayer().username);
 
             if (primaryPos == null || secondaryPos == null) {
-                commandSender.getPlayer().addChatMessage("Positions aren't set!");
+                commandSender.getPlayer().sendMessage("Positions aren't set!");
                 return true;
             }
 

--- a/src/main/java/cookie/worldedit/mixin/ItemMixin.java
+++ b/src/main/java/cookie/worldedit/mixin/ItemMixin.java
@@ -21,10 +21,10 @@ public abstract class ItemMixin {
                 int[] hitPosition = {blockX, blockY, blockZ};
                 if (!entityplayer.isSneaking()) {
                     WandPlayerData.primaryPositions.put(entityplayer.username, hitPosition);
-                    entityplayer.addChatMessage("Set primary position at " + blockX + ", " + blockY + ", " + blockZ);
+                    entityplayer.sendMessage("Set primary position at " + blockX + ", " + blockY + ", " + blockZ);
                 } else if (entityplayer.isSneaking()) {
                     WandPlayerData.secondaryPositions.put(entityplayer.username, hitPosition);
-                    entityplayer.addChatMessage("Set secondary position at " + blockX + ", " + blockY + ", " + blockZ);
+                    entityplayer.sendMessage("Set secondary position at " + blockX + ", " + blockY + ", " + blockZ);
                 }
             }
         }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,7 +34,8 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.13.3"
+    "minecraft": "^7.2-beta",
+    "fabricloader": ">=0.15.5"
   },
   "suggests": {
   }


### PR DESCRIPTION
- Replaced non-existant `addChatMessage` to `sendMessage`
- Updated gradle from `7.4` to `8.3` due to bug with binaries existing on 7.4
- Updated Mod Menu from `2.0.3` to `2.0.6`
- Moved version control of Mod Menu to `gradle.properties` as `mod_menu_version` for easier management
- Updated Halplibe from `3.1.1` to `4.0.1`
- Updated loader from `0.14.19-babric.3-bta` to `0.15.6-babric.6-bta`
- Added Minecraft dependency check for `7.2-beta` and higher in `fabric.mod.json`